### PR TITLE
Allow ble-uart to install with newer versions of Node.js

### DIFF
--- a/ble-uart.js
+++ b/ble-uart.js
@@ -1,5 +1,5 @@
 module.exports = function(RED) {
-    var noble = require('noble');
+    var noble = require('@abandonware/noble');
 
     function BleUartNode(config) {
         RED.nodes.createNode(this, config);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.3",
     "description": "A Node-RED node that uses the Noble to interact with BLE devices that support the UART profile by Nordic Semiconductor",
     "dependencies": {
-        "noble": ">=1.6.0"
+        "@abandonware/noble": ">=1.9.2-15"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Switch to using @abandonware/noble (since Noble hasn't been updated for a while). This has a few changes which allow it to build with newer versions of Node

Fix https://github.com/kotobuki/node-red-contrib-ble-uart/issues/2